### PR TITLE
Update notebook2script.py

### DIFF
--- a/nbs/dl2/notebook2script.py
+++ b/nbs/dl2/notebook2script.py
@@ -65,6 +65,7 @@ def notebook2scriptSingle(fname):
     for cell in code_cells: module += ''.join(cell['source'][1:]) + '\n\n'
     # remove trailing spaces
     module = re.sub(r' +$', '', module, flags=re.MULTILINE)
+    if not (fname.parent/'exp').exists(): (fname.parent/'exp').mkdir()
     output_path = fname.parent/'exp'/fname_out
     open(output_path,'w').write(module[:-2])
     print(f"Converted {fname} to {output_path}")


### PR DESCRIPTION
issue: without checking "exp" directory exists it throws an exception!
fix: when "exp" directory doesn't exists the script makes the directory.
